### PR TITLE
Fix README install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you open the image using `./pharo-ui Pharo.image`, the image should give the 
 The following code should open a small UI:
 
 ```Smalltalk
-GtkApplication ensureRunning.
+GEngine ensureRunning.
 GtkRunLoop defer: [
 	GtkWindow new 
 		title: 'Gtk3 Window';


### PR DESCRIPTION
This worked on my Debian. The GtkApplication class wasn't present and I found GEngine as a possible replacement. And it worked!